### PR TITLE
feat: validação e persistência de Cardapio

### DIFF
--- a/app/src/main/java/com/example/edusnack/model/Cardapio.kt
+++ b/app/src/main/java/com/example/edusnack/model/Cardapio.kt
@@ -1,12 +1,22 @@
 package com.example.edusnack.model
 
+import com.google.firebase.Timestamp
+import com.google.firebase.firestore.DocumentId
 import java.util.*
 
 data class Cardapio(
-    val id: String = "",
-    val data: Date = Date(),
-    val refeicao: String = "",
-    val descricao: String = "",
-    val valorNutricional: String = "",
-    val autorId: String = ""
-)
+    @DocumentId
+    var id: String = "",
+    var data: Timestamp = Timestamp.now(),
+    var refeicao: String = "",
+    var descricao: String = "",
+    var valorNutricional: String = "",
+    var autorId: String = ""
+){
+    fun validarOuErro(): String? {
+        if (refeicao.isBlank()) return "Refeição não pode estar em branco"
+        if (descricao.isBlank()) return "Descrição não pode estar em branco"
+        if (autorId.isBlank()) return "Autor não pode estar em branco"
+        return null
+    }
+}

--- a/app/src/main/java/com/example/edusnack/repository/CardapioRepository.kt
+++ b/app/src/main/java/com/example/edusnack/repository/CardapioRepository.kt
@@ -1,6 +1,7 @@
 package com.example.edusnack.repository
 
 import com.example.edusnack.model.Cardapio
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import kotlinx.coroutines.tasks.await
@@ -8,34 +9,81 @@ import java.util.*
 
 class CardapioRepository {
 
-    private val db = FirebaseFirestore.getInstance()
-    private val collection = db.collection("cardapios")
+    private val collection = FirebaseFirestore.getInstance().collection("cardapios")
 
-    suspend fun adicionarCardapio(cardapio: Cardapio) {
-        val docRef = collection.document()
-        collection.document(docRef.id).set(cardapio.copy(id = docRef.id)).await()
-    }
+    suspend fun adicionarCardapio(cardapio: Cardapio): Result<String> {
+        cardapio.validarOuErro()?.let {
+            return Result.failure(IllegalArgumentException(it))
+        }
 
-    suspend fun editarCardapio(cardapio: Cardapio) {
-        if (cardapio.id.isNotEmpty()) {
-            collection.document(cardapio.id).set(cardapio).await()
+        return try {
+            val docRef = collection.add(cardapio).await()
+            Result.success(docRef.id)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 
-    suspend fun listarCardapiosPorData(data: Date): List<Cardapio> {
-        val snapshot: QuerySnapshot = collection
-            .whereEqualTo("data", data)
-            .get()
-            .await()
-        return snapshot.toObjects(Cardapio::class.java)
+    suspend fun editarCardapio(cardapio: Cardapio): Result<Unit> {
+        cardapio.validarOuErro()?.let {
+            return Result.failure(IllegalArgumentException(it))
+        }
+
+        if (cardapio.id.isEmpty()) {
+            return Result.failure(IllegalArgumentException("ID vazio"))
+        }
+
+        return try {
+            collection.document(cardapio.id).set(cardapio).await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    suspend fun listarTodosCardapios(): List<Cardapio> {
-        val snapshot = collection.get().await()
-        return snapshot.toObjects(Cardapio::class.java)
+    // Essa função só funciona se o Timestamp for exato
+    suspend fun listarCardapiosPorData(data: Timestamp): Result<List<Cardapio>> {
+        return try {
+            val snapshot = collection
+                .whereEqualTo("data", data)
+                .get()
+                .await()
+            Result.success(snapshot.toObjects(Cardapio::class.java))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    suspend fun removerCardapio(cardapioId: String) {
-        collection.document(cardapioId).delete().await()
+    suspend fun listarTodosCardapios(): Result<List<Cardapio>> {
+        return try {
+            val snapshot = collection.get().await()
+            Result.success(snapshot.toObjects(Cardapio::class.java))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun buscarCardapioPorId(id: String): Result<Cardapio> {
+        return try {
+            val doc = collection.document(id).get().await()
+            doc.toObject(Cardapio::class.java)?.let {
+                Result.success(it)
+            } ?: Result.failure(NoSuchElementException("Cardápio não encontrado"))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    suspend fun removerCardapio(id: String): Result<Unit> {
+        if (id.isEmpty()) {
+            return Result.failure(IllegalArgumentException("ID vazio"))
+        }
+
+        return try {
+            collection.document(id).delete().await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }


### PR DESCRIPTION
Complementa a implementação do modelo Cardapio, adicionando validação dos campos obrigatórios e finalizando o repositório responsável pela persistência no Firebase Firestore. Foram incluídas as operações de adicionar, editar, listar e remover cardápios, garantindo que os dados existentes sejam validados e enviados corretamente ao backend.